### PR TITLE
Fix incorrect memory fence usage in ring

### DIFF
--- a/src/ring.c
+++ b/src/ring.c
@@ -23,9 +23,11 @@
 #  if defined(_M_AMD64) || defined(_M_IX86) || defined(_M_X64)
     /* acquire and release fences are only necessary for
      * non-x86 systems. In fact, gcc will generate no
-     * instructions for acq/rel fences on x86. */
-#    define ZIX_READ_BARRIER()
-#    define ZIX_WRITE_BARRIER()
+     * instructions for acq/rel fences on x86. We only need
+     * to prevent compiler reordering. */
+#    include <intrin.h>
+#    define ZIX_READ_BARRIER() _ReadBarrier()
+#    define ZIX_WRITE_BARRIER() _WriteBarrier()
 #  else
 #    include <windows.h>
 #    define ZIX_READ_BARRIER() MemoryBarrier()


### PR DESCRIPTION
I noticed this problem in another project using zix, so I figure it's necessary to fix the upstream as well.

The current implementation seems to be misguided by the naming of barrier macros. The barrier before read pointer increment should be a release fence instead of an acquire fence,
```diff
-  ZIX_READ_BARRIER();
+  ZIX_WRITE_BARRIER();
   ring->read_head = (r + size) & ring->size_mask;
```
or otherwise the fence cannot prevent [store-store reordering][1], i.e. stores happens before pointer increment might be visible after the increment to the other thread. I also added the missing acquire fences when loading a pointer from the other thread.

I don't think this bug would lead to a major problem, since it only affects read operations, which does not store to the shared buffer, but since memory ordering problems are almost impossible to debug, it's better to be safe here.

Also, on x86, acquire/release fences [should be no-ops][2]. Using full memory fences on x86 msvc brings unnecessary syncing overhead. They should be only enabled for ARM.

For a reference implementation to verify correctness, the [`spsc_queue`](https://github.com/steinwurf/boost/blob/master/boost/lockfree/spsc_queue.hpp) from boost might be useful.

[1]: https://preshing.com/20130922/acquire-and-release-fences/
[2]: https://www.cl.cam.ac.uk/~pes20/cpp/cpp0xmappings.html
